### PR TITLE
use published cacaos crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/spruceid/cacao-zcap-rs/"
 
 [dependencies]
 ssi = { version = ">=0.3, <0.5", path = "../ssi" }
-cacao = { path = "../cacao-rs" }
+cacaos = "0.1"
 uint = "=0.9.1"
 chrono = "0.4"
 serde = { version = "1.0", features = ["derive"] }

--- a/examples/regenerate-test-vectors.rs
+++ b/examples/regenerate-test-vectors.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
-use cacao::siwe_cacao::SignInWithEthereum;
-use cacao::BasicSignature;
-use cacao::{Payload, CACAO};
+use cacaos::siwe_cacao::SignInWithEthereum;
+use cacaos::BasicSignature;
+use cacaos::{Payload, CACAO};
 use cacao_zcap::{cacao_to_zcap, CapabilityChainItem};
 use siwe::Message;
 use std::fs::File;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
-use cacao::siwe_cacao::SignInWithEthereum;
-use cacao::{Header, Payload, SignatureScheme, Version as CacaoVersion, CACAO};
+use cacaos::siwe_cacao::SignInWithEthereum;
+use cacaos::{Header, Payload, SignatureScheme, Version as CacaoVersion, CACAO};
 use chrono::prelude::DateTime;
 use iri_string::types::UriString;
 use libipld::{
@@ -944,7 +944,7 @@ impl ProofSuite for CacaoZcapProof2022 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cacao::BasicSignature;
+    use cacaos::BasicSignature;
     use pretty_assertions::assert_eq;
     use siwe::Message;
 


### PR DESCRIPTION
`cacaos` has been published at `0.1`, this pr updates the dependancy to use that version